### PR TITLE
fix(docker): make the image work with no network at runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,29 @@
+# Resolve the Delta and Unity Catalog connector jars at build time, using the same Ivy
+# resolver spark-submit uses at runtime, so a job container never needs Maven Central.
+# Reusing spark-submit (rather than curl-ing jars by hand) is deliberate: it writes the
+# ivy-*.xml metadata alongside the jars, and without that metadata Ivy goes back to the
+# network even when the jar is already on disk.
+#
+# --platform=$BUILDPLATFORM: jars are architecture-independent, so this stage does not need
+# to run under QEMU during the multi-arch release build.
+FROM --platform=$BUILDPLATFORM apache/spark:3.5.3-scala2.12-java17-python3-ubuntu AS sparkjars
+
+USER root
+
+# Keep these in step with docker_executor.DEFAULT_DELTA_PACKAGE and the connector coordinate
+# documented for spark.table() resolution.
+ARG DELTA_PACKAGE=io.delta:delta-spark_2.12:3.2.1
+ARG UC_PACKAGE=io.unitycatalog:unitycatalog-spark_2.12:0.2.1
+
+RUN mkdir -p /opt/ivy/cache /opt/ivy/jars && \
+    echo 'pass' > /tmp/warmup.py && \
+    /opt/spark/bin/spark-submit \
+        --packages "${DELTA_PACKAGE},${UC_PACKAGE}" \
+        --conf spark.jars.ivy=/opt/ivy \
+        /tmp/warmup.py && \
+    ls /opt/ivy/jars/*.jar > /dev/null
+
+
 FROM python:3.11-slim
 
 WORKDIR /opt/minilake
@@ -16,6 +42,21 @@ COPY README.md README.md
 # Install minilake with the MCP extra. Baked into the image so MINILAKE_MCP=1 is all that's
 # needed to turn the MCP server on; the extra stays optional for PyPI installs.
 RUN pip install --no-cache-dir -e ".[mcp]"
+
+# Pre-install DuckDB's `delta` extension. Without this the server downloads it from
+# extensions.duckdb.org on every first boot, into a $HOME path that is not a volume — so it
+# is re-fetched for each new container, and fails outright with no internet access.
+# The directory is explicit rather than $HOME/.duckdb so it survives `docker run --user`, and
+# sits outside WORKDIR so a bind-mount over the source tree cannot shadow it.
+ENV MINILAKE_DUCKDB_EXTENSION_DIR=/opt/duckdb-extensions
+RUN python -c "import duckdb, os; duckdb.connect(config={'extension_directory': os.environ['MINILAKE_DUCKDB_EXTENSION_DIR']}).execute('INSTALL delta')" && \
+    find "$MINILAKE_DUCKDB_EXTENSION_DIR" -name 'delta.duckdb_extension' | grep -q . && \
+    chmod -R a+rX "$MINILAKE_DUCKDB_EXTENSION_DIR"
+
+# Delta / Unity Catalog jars resolved in the sparkjars stage above. Copied into the volume
+# shared with job containers on first use (see docker_executor._seed_ivy_cache).
+COPY --from=sparkjars /opt/ivy /opt/ivy-cache
+ENV MINILAKE_IVY_SEED=/opt/ivy-cache
 
 # Create data directory
 RUN mkdir -p /data

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,3 +1,20 @@
+# Same build-time jar resolution as the runtime image — see Dockerfile for the rationale.
+FROM --platform=$BUILDPLATFORM apache/spark:3.5.3-scala2.12-java17-python3-ubuntu AS sparkjars
+
+USER root
+
+ARG DELTA_PACKAGE=io.delta:delta-spark_2.12:3.2.1
+ARG UC_PACKAGE=io.unitycatalog:unitycatalog-spark_2.12:0.2.1
+
+RUN mkdir -p /opt/ivy/cache /opt/ivy/jars && \
+    echo 'pass' > /tmp/warmup.py && \
+    /opt/spark/bin/spark-submit \
+        --packages "${DELTA_PACKAGE},${UC_PACKAGE}" \
+        --conf spark.jars.ivy=/opt/ivy \
+        /tmp/warmup.py && \
+    ls /opt/ivy/jars/*.jar > /dev/null
+
+
 FROM python:3.11-slim
 
 WORKDIR /opt/minilake
@@ -29,6 +46,19 @@ RUN uv pip install -e ".[mcp]" --python /usr/local/bin/python && \
     pandas>=2.0 \
     pyarrow>=14.0 \
     --python /usr/local/bin/python
+
+# Mirror the runtime image's pre-baked DuckDB extension and Ivy cache. The test runner does
+# not execute jobs itself, but it shares the data volume with the server container, and
+# keeping the two images symmetric is what stops one of them from silently drifting offline.
+# Both live outside WORKDIR: docker-compose.test.yml bind-mounts the repo over /opt/minilake,
+# which would otherwise hide them at runtime.
+ENV MINILAKE_DUCKDB_EXTENSION_DIR=/opt/duckdb-extensions
+RUN python -c "import duckdb, os; duckdb.connect(config={'extension_directory': os.environ['MINILAKE_DUCKDB_EXTENSION_DIR']}).execute('INSTALL delta')" && \
+    find "$MINILAKE_DUCKDB_EXTENSION_DIR" -name 'delta.duckdb_extension' | grep -q . && \
+    chmod -R a+rX "$MINILAKE_DUCKDB_EXTENSION_DIR"
+
+COPY --from=sparkjars /opt/ivy /opt/ivy-cache
+ENV MINILAKE_IVY_SEED=/opt/ivy-cache
 
 # Create data directory for tests
 RUN mkdir -p /data

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -315,7 +315,7 @@ after each item, run via
 
 1. Create the table with `table_type=EXTERNAL`, `data_source_format=DELTA`, and an explicit `storage_location` (a path under the shared data volume, e.g. `/data/delta/<catalog>/<schema>/<table>`). minilake does **not** create a DuckDB-native table for this — it only registers the metadata and pre-creates `storage_location` as a world-writable directory (`0777`), because sibling containers that write to it (Spark job images, JupyterLab) each run as their own non-root UID/GID convention and there is no single group that covers all of them on a local-dev machine.
 2. Anything writes real Delta files to `storage_location` — a real Spark session (`df.write.format("delta").save(...)`), the notebook service, or the lightweight `deltalake` (delta-rs) package.
-3. `SELECT * FROM catalog.schema.table` is rewritten internally to `delta_scan('storage_location')` (DuckDB's `delta` extension, `INSTALL`/`LOAD`ed at startup) instead of the native-DuckDB-table path used for MANAGED tables.
+3. `SELECT * FROM catalog.schema.table` is rewritten internally to `delta_scan('storage_location')` (DuckDB's `delta` extension, `LOAD`ed at startup) instead of the native-DuckDB-table path used for MANAGED tables.
 
 **Request Format:**
 
@@ -344,7 +344,7 @@ after each item, run via
   - job containers join minilake's Docker network (`docker_executor._resolve_network`), or the connector cannot reach the API at all
 
 - ⚠️ **Only EXTERNAL Delta tables are visible to Spark**: a MANAGED table is a DuckDB table with no files, so it has nothing for Spark to read. This is not a gap to close — the alternative, Unity Catalog's own managed tables, use the `catalogManaged` Delta feature whose commit log lives partly in the catalog, and DuckDB's `delta_scan` cannot read those at all (`Catalog-managed table requires max_catalog_version to be set`). Keeping MANAGED on DuckDB is what preserves the fast SQL path.
-- ⚠️ First `delta_scan()` requires network access once, to `INSTALL` DuckDB's `delta` extension (fails loudly, not silently, if unavailable)
+- ✅ **No network needed in Docker**: the image installs DuckDB's `delta` extension at build time into `MINILAKE_DUCKDB_EXTENSION_DIR` (`/opt/duckdb-extensions`) and the server only `LOAD`s it, with `autoinstall_known_extensions` off so nothing can be fetched behind your back. A `pip install minilake` still `INSTALL`s the extension from `extensions.duckdb.org` on first run, and so needs network access once. Verify the image with `./scripts/verify-offline.sh`.
 
 **Status:** ✅ Complete and tested
 
@@ -445,7 +445,8 @@ after each item, run via
 
 **Known limitations:**
 
-- ⚠️ First run pulls the Spark image if not already cached (can take a while; subsequent runs are fast — `prewarm_spark_image()` pre-pulls it best-effort at server startup)
+- ⚠️ First run pulls the Spark image if not already cached (can take a while; subsequent runs are fast — `prewarm_spark_image()` pre-pulls it best-effort at server startup, and `MINILAKE_SPARK_PREWARM=0` skips the attempt on an offline machine). This is the one dependency an image cannot bake in — a Docker image cannot contain another Docker image — so offline use means pulling `apache/spark:3.5.3-scala2.12-java17-python3-ubuntu` once while you still have network
+- ✅ The Delta and Unity Catalog connector jars *are* baked in: the image resolves them at build time with `spark-submit` and copies that Ivy cache onto the shared data volume on first use (`docker_executor._seed_ivy_cache`), so `spark-submit --packages` resolves locally. Only extra coordinates you pass yourself (`libraries` on a task, `packages=[...]` on the MCP tool) still need Maven Central
 - ⚠️ Job/run history survives a restart only when `MINILAKE_PERSIST=1` (see Persistence below) — running job containers are not resumed, only completed run records are restored
 
 **Status:** ✅ Complete and tested (`tests/test_jobs.py`, `tests/test_docker_executor.py` — real container/subprocess execution, DAG scheduling, secret injection, `sql_task`)

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -4,8 +4,8 @@
 
 **minilake** is a local Databricks API emulator backed by DuckDB for real SQL execution. This document details all implemented features, APIs, and their current status.
 
-**Latest Update:** 2026-07-30
-**Version:** 1.5.1
+**Latest Update:** 2026-08-08
+**Version:** 1.6.0
 **Project Status:** Core SQL + UC (per-catalog isolation) + Jobs (real DAG scheduling) + Workspace + DBFS + Files + Secrets + Clusters + Permissions + real Spark/Delta execution all working and tested; `MINILAKE_PERSIST` is now actually wired in. See [Known Limitations](#known-limitations) for what's intentionally not built (this is a single-dev local tool, not a multi-tenant server)
 
 ---

--- a/README.md
+++ b/README.md
@@ -43,7 +43,11 @@ docker compose up -d
 curl http://localhost:8000/_minilake/health
 ```
 
-No account, no API key, no sign-up. Then point any Databricks client at it:
+No account, no API key, no sign-up — and the container image downloads nothing at runtime:
+DuckDB's `delta` extension and the Delta / Unity Catalog Spark jars are baked in at build
+time, so it works air-gapped ([details](https://github.com/dmux/minilake/blob/main/docs/getting-started.md#offline-use)).
+
+Then point any Databricks client at it:
 
 ```python
 from databricks.sdk import WorkspaceClient

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,7 +13,8 @@ Everything is set through environment variables. Nothing needs a config file.
 | `MINILAKE_DATA_DIR` | `./data` | Where catalogs, workspace files, DBFS and Delta data live |
 | `MINILAKE_VERBOSE` | unset | `1` for full `INFO` logs (per-request access logs, SQL and job traces). Off by default — only the startup banner and warnings appear |
 | `MINILAKE_SERVICES` | (all) | Comma-separated allowlist, e.g. `unity_catalog,sql_statements,sql_warehouses` |
-| `MINILAKE_DUCKDB_MEMORY_LIMIT` | `4GB` | Passed to DuckDB |
+| `MINILAKE_DUCKDB_MEMORY_LIMIT` | `4GB` | Declared but not yet applied to any connection — currently a no-op |
+| `MINILAKE_DUCKDB_EXTENSION_DIR` | unset (`/opt/duckdb-extensions` in the image) | Directory of pre-installed DuckDB extensions. When set, the server only `LOAD`s the `delta` extension and never downloads it, which is what makes the image work with no internet access |
 
 ### Persistence
 
@@ -31,6 +32,8 @@ Everything is set through environment variables. Nothing needs a config file.
 | `MINILAKE_DELTA_PACKAGE` | `io.delta:delta-spark_2.12:3.2.1` | Maven coordinate for the Delta jars. Must match the Spark version in the image |
 | `MINILAKE_DOCKER_VOLUME` | unset | Named volume backing `MINILAKE_DATA_DIR`, shared with spawned job containers. Falls back to introspecting minilake's own mounts |
 | `MINILAKE_DOCKER_NETWORK` | unset | Network to attach job containers to, so a task can call back into the API. Falls back to introspection when minilake is on exactly one network |
+| `MINILAKE_IVY_SEED` | unset (`/opt/ivy-cache` in the image) | Pre-resolved Delta / Unity Catalog jars, copied onto the shared data volume on first job run so `spark-submit --packages` resolves without Maven Central |
+| `MINILAKE_SPARK_PREWARM` | unset | `0` skips the best-effort `docker pull` of the Spark image at startup — worth setting on a machine with no network, where the attempt only costs a timeout |
 
 ### TLS
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -44,6 +44,24 @@ docker compose up -d
 `docker compose` wires the socket, the volume and the environment for you, and is the
 closest thing to a reference deployment.
 
+### Offline use
+
+The image downloads nothing at runtime. DuckDB's `delta` extension and the Delta / Unity
+Catalog Spark jars are both resolved at build time and shipped inside it, so a container
+reads EXTERNAL Delta tables on an air-gapped machine. `./scripts/verify-offline.sh` proves
+it by running the image under `docker run --network none`.
+
+One thing an image cannot contain is another image. If you want Jobs to run on real Spark
+offline, pull the executor image once while you still have network:
+
+```bash
+docker pull apache/spark:3.5.3-scala2.12-java17-python3-ubuntu
+```
+
+Then set `MINILAKE_SPARK_PREWARM=0` to stop minilake from re-checking for it at startup.
+Maven coordinates you supply yourself — a task's `libraries`, or `packages=[...]` on the
+MCP job tool — are still fetched from Maven Central on first use.
+
 ## Verify
 
 ```bash

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -26,7 +26,12 @@ That triggers [`release.yml`](../.github/workflows/release.yml), which:
    everything downstream — a mismatch would ship an image labelled one version and a wheel
    containing another, and a PyPI upload cannot be replaced afterwards.
 2. Builds a multi-arch image (`amd64` + `arm64`) and pushes it to GHCR as
-   `ghcr.io/dmux/minilake:X.Y.Z`, `:X.Y` and `:latest`
+   `ghcr.io/dmux/minilake:X.Y.Z`, `:X.Y` and `:latest`. The build needs network for more
+   than pip: it also installs DuckDB's `delta` extension and resolves the Delta / Unity
+   Catalog Spark jars, which is what lets the resulting image run with none. That costs
+   roughly 100 MB of image size and one extra `spark-submit` stage, and the build fails
+   outright if either fetch does not land — better than silently publishing an image that
+   goes back to downloading at boot.
 3. Builds the sdist and wheel and **publishes them to PyPI**
 4. Creates a [GitHub Release](https://github.com/dmux/minilake/releases) with generated notes
 

--- a/docs/spark-and-delta.md
+++ b/docs/spark-and-delta.md
@@ -78,6 +78,11 @@ Anything touching Delta needs the jars, which the base image does not ship. Over
 is `delta=True`; over the Jobs API it is a `libraries` entry with the Maven coordinate
 `io.delta:delta-spark_2.12:3.2.1`.
 
+Those jars — and the Unity Catalog connector's — are resolved when the minilake image is
+built and copied onto the shared data volume on the first job run, so `--packages` resolves
+from the local Ivy cache and no job needs Maven Central. Any *other* coordinate you pass
+still does.
+
 ## Reading by name with Unity Catalog
 
 `spark.table("catalog.schema.table")` resolves against minilake. Spark's

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "minilake"
-version = "1.5.1"
+version = "1.6.0"
 description = "A local Databricks API emulator backed by DuckDB."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/scripts/verify-offline.sh
+++ b/scripts/verify-offline.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# Proves the published image needs no network at runtime.
+#
+# `docker run --network none` leaves loopback up (so the server still boots and its health
+# check still works) while making every outbound request fail immediately. Anything that
+# would have been downloaded on first boot shows up here as a hard failure instead of a
+# slow, silent degradation.
+#
+# Usage: ./scripts/verify-offline.sh [image-tag]
+
+set -euo pipefail
+
+IMAGE="${1:-minilake:offline-check}"
+
+if [ -z "${1:-}" ]; then
+    echo "==> Building ${IMAGE}"
+    docker build -t "${IMAGE}" .
+fi
+
+echo "==> Checking the DuckDB delta extension loads with no network"
+# -i is load-bearing: without stdin attached, `python -` reads nothing and exits 0, and the
+# check passes without having checked anything.
+docker run --rm -i --network none "${IMAGE}" python - <<'PY'
+import os
+import sys
+
+import duckdb
+
+extension_dir = os.environ["MINILAKE_DUCKDB_EXTENSION_DIR"]
+conn = duckdb.connect(config={"extension_directory": extension_dir, "autoinstall_known_extensions": False})
+conn.execute("LOAD delta")
+name, loaded, installed, path = conn.execute(
+    "SELECT extension_name, loaded, installed, install_path FROM duckdb_extensions() "
+    "WHERE extension_name = 'delta'"
+).fetchone()
+if not (loaded and installed and path.startswith(extension_dir)):
+    sys.exit(f"delta extension not served from the image: loaded={loaded} installed={installed} path={path}")
+print(f"    delta {duckdb.__version__} loaded from {path}")
+PY
+
+echo "==> Checking the Spark Delta / Unity Catalog jars are in the image"
+docker run --rm --network none "${IMAGE}" sh -c '
+    set -e
+    ls "$MINILAKE_IVY_SEED"/jars/*.jar > /dev/null
+    printf "    %s jars under %s\n" "$(ls "$MINILAKE_IVY_SEED"/jars/*.jar | wc -l)" "$MINILAKE_IVY_SEED"
+    # Ivy names jars <group>_<artifact>-<version>.jar in its jars/ dir.
+    ls "$MINILAKE_IVY_SEED"/jars/ | grep -q "^io.delta_delta-spark" || { echo "delta-spark jar missing"; exit 1; }
+    ls "$MINILAKE_IVY_SEED"/jars/ | grep -q "^io.unitycatalog_unitycatalog-spark" || { echo "unitycatalog-spark jar missing"; exit 1; }
+'
+
+echo "==> Booting the server with no network and checking it reports no extension failure"
+container=$(docker run -d --rm --network none "${IMAGE}")
+trap 'docker rm -f "${container}" > /dev/null 2>&1 || true' EXIT
+
+for _ in $(seq 1 30); do
+    if docker exec "${container}" curl -sf http://localhost:8000/_minilake/health > /dev/null 2>&1; then
+        break
+    fi
+    sleep 1
+done
+
+docker exec "${container}" curl -sf http://localhost:8000/_minilake/health > /dev/null
+logs=$(docker logs "${container}" 2>&1)
+if echo "${logs}" | grep -iE "failed to (load|install).*delta extension"; then
+    echo "The server could not load the delta extension offline." >&2
+    exit 1
+fi
+
+echo
+echo "OK — ${IMAGE} boots and serves Delta reads with no network access."
+echo "Note: running a Spark job still needs the Spark image locally:"
+echo "  docker pull apache/spark:3.5.3-scala2.12-java17-python3-ubuntu"

--- a/src/minilake/config.py
+++ b/src/minilake/config.py
@@ -37,6 +37,13 @@ class Settings(BaseSettings):
 
     # DuckDB settings
     duckdb_memory_limit: str = os.getenv("MINILAKE_DUCKDB_MEMORY_LIMIT", "4GB")
+    # Directory holding pre-installed DuckDB extensions. The Docker image sets this and
+    # populates it at build time, which is what makes the container work with no network:
+    # when it is set, startup only LOADs the `delta` extension and never INSTALLs it. Unset
+    # (a plain `pip install minilake`) keeps the download-on-first-run behaviour.
+    duckdb_extension_dir: Optional[Path] = (
+        Path(os.environ["MINILAKE_DUCKDB_EXTENSION_DIR"]) if os.getenv("MINILAKE_DUCKDB_EXTENSION_DIR") else None
+    )
 
     # TLS / native HTTPS — lets the Databricks CLI (which wants an https:// host)
     # talk to minilake without a separate TLS proxy. When enabled, minilake serves

--- a/src/minilake/docker_executor.py
+++ b/src/minilake/docker_executor.py
@@ -16,6 +16,7 @@ see files written under `settings.data_dir` (e.g. imported workspace notebooks).
 import asyncio
 import logging
 import os
+import shutil
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
@@ -41,6 +42,10 @@ DEFAULT_TIMEOUT_SECONDS = 600
 # all ("Catalog-managed table requires max_catalog_version to be set"). That would
 # break the write-with-Spark/read-with-SQL loop this project is built around.
 DEFAULT_DELTA_PACKAGE = os.environ.get("MINILAKE_DELTA_PACKAGE", "io.delta:delta-spark_2.12:3.2.1")
+
+# Marks an Ivy home as already seeded from MINILAKE_IVY_SEED, so the copy happens once per
+# data volume rather than on every job run.
+_IVY_SEED_MARKER = ".minilake-seeded"
 
 
 def _executor_mode() -> str:
@@ -252,7 +257,7 @@ async def run_python_task(
 
 
 def _prepare_ivy_cache() -> str:
-    """Create the Ivy home on the shared volume and return it.
+    """Create the Ivy home on the shared volume, seed it from the image, and return it.
 
     Ivy writes its resolved-*.xml descriptors into `<ivy.home>/cache` but never
     mkdirs it, so pointing spark.jars.ivy at a fresh directory makes the very
@@ -261,7 +266,51 @@ def _prepare_ivy_cache() -> str:
     ivy_home = settings.data_dir / ".ivy2-cache"
     for path in (ivy_home / "cache", ivy_home / "jars"):
         ensure_writable_dir(path)
+    _seed_ivy_cache(ivy_home)
     return str(ivy_home)
+
+
+def _seed_ivy_cache(ivy_home: Path) -> None:
+    """Copy the image's pre-resolved Delta/Unity-Catalog jars into the shared Ivy home.
+
+    The Docker image resolves those coordinates at build time into MINILAKE_IVY_SEED, so a
+    job never has to reach Maven Central. That directory lives inside *this* container
+    though, and the Spark container is a sibling: the only filesystem the two share is the
+    data volume, so the cache has to be copied there rather than mounted.
+
+    Copied once per volume, guarded by a marker file. Failure is a warning, not an error —
+    without the seed, resolution merely falls back to the network, which is what happened
+    before the cache was baked in at all.
+    """
+    seed = os.environ.get("MINILAKE_IVY_SEED")
+    if not seed:
+        return
+    seed_path = Path(seed)
+    marker = ivy_home / _IVY_SEED_MARKER
+    if marker.exists() or not seed_path.is_dir():
+        return
+    try:
+        # dirs_exist_ok: anything the user already resolved into this volume wins over the
+        # baked copy rather than being clobbered.
+        shutil.copytree(seed_path, ivy_home, dirs_exist_ok=True)
+        # The Spark image runs as uid 185 and Ivy writes into this tree. ensure_writable_dir
+        # only walks from a leaf up to data_dir, so the copied subtree needs its own pass.
+        for root, dirs, files in os.walk(ivy_home):
+            for name in dirs:
+                _chmod_quietly(Path(root) / name, 0o777)
+            for name in files:
+                _chmod_quietly(Path(root) / name, 0o666)
+        marker.touch()
+        logger.info(f"Seeded Ivy cache at {ivy_home} from {seed_path}")
+    except OSError as e:
+        logger.warning(f"Could not seed the Ivy cache from {seed_path} (non-critical): {e}")
+
+
+def _chmod_quietly(path: Path, mode: int) -> None:
+    try:
+        path.chmod(mode)
+    except OSError:
+        pass
 
 
 def prewarm_spark_image(image: Optional[str] = None) -> None:
@@ -269,8 +318,16 @@ def prewarm_spark_image(image: Optional[str] = None) -> None:
 
     Called once from app startup in a background task so the *first* real job
     run doesn't pay the image-pull cold-start cost. No-op in subprocess mode.
+
+    This is the one thing an image cannot bake in — a Docker image cannot contain another
+    Docker image — so on an offline machine it is the single remaining network call at
+    startup. It already fails harmlessly, but `MINILAKE_SPARK_PREWARM=0` skips the attempt
+    (and its several-second timeout) outright.
     """
     if _executor_mode() == "subprocess":
+        return
+    if os.environ.get("MINILAKE_SPARK_PREWARM", "").strip().lower() in ("0", "false", "no"):
+        logger.info("Skipping Spark image pre-pull (MINILAKE_SPARK_PREWARM disabled)")
         return
     spark_image = image or os.environ.get("MINILAKE_SPARK_IMAGE", DEFAULT_SPARK_IMAGE)
     try:

--- a/src/minilake/duckdb_pool.py
+++ b/src/minilake/duckdb_pool.py
@@ -7,6 +7,8 @@ from typing import Optional
 
 import duckdb
 
+from minilake.config import settings
+
 logger = logging.getLogger(__name__)
 
 
@@ -18,9 +20,13 @@ class DuckDBPool:
     - All connections are serialized with asyncio.Lock to respect DuckDB's single-writer model
     """
 
-    def __init__(self, data_dir: Path):
+    def __init__(self, data_dir: Path, extension_dir: Optional[Path] = None):
         self.data_dir = Path(data_dir)
         self.data_dir.mkdir(parents=True, exist_ok=True)
+
+        # Where DuckDB looks for extensions. Set by the Docker image to a directory populated
+        # at build time; None for a plain pip install, where extensions are downloaded on demand.
+        self.extension_dir = extension_dir if extension_dir is not None else settings.duckdb_extension_dir
 
         # Shared Unity Catalog connection
         self._uc_connection: Optional[duckdb.DuckDBPyConnection] = None
@@ -33,22 +39,59 @@ class DuckDBPool:
         # Global lock for warehouse dict modifications
         self._warehouse_dict_lock = asyncio.Lock()
 
+    def _connect_config(self) -> dict:
+        """Connection config pinning DuckDB to the pre-installed extension directory.
+
+        Empty when there is none, which leaves DuckDB on its default `$HOME/.duckdb`.
+        `autoinstall_known_extensions=False` is the part that guarantees offline operation:
+        without it DuckDB silently reaches for extensions.duckdb.org the first time a query
+        touches a function from an extension that isn't loaded yet.
+        """
+        if self.extension_dir is None:
+            return {}
+        return {
+            "extension_directory": str(self.extension_dir),
+            "autoinstall_known_extensions": False,
+        }
+
     async def _get_uc_connection(self) -> duckdb.DuckDBPyConnection:
         """Get or create the shared Unity Catalog DuckDB connection."""
         if self._uc_connection is None:
             uc_path = self.data_dir / "unity_catalog.duckdb"
-            self._uc_connection = duckdb.connect(str(uc_path))
+            self._uc_connection = duckdb.connect(str(uc_path), config=self._connect_config())
             await self._init_delta_extension()
         return self._uc_connection
 
     async def _init_delta_extension(self) -> None:
-        """Install/load DuckDB's `delta` extension so EXTERNAL Delta tables
-        (written by e.g. a real Spark/notebook session sharing the data volume)
-        can be read via `delta_scan(storage_location)`. Best-effort: querying
-        an EXTERNAL Delta table will fail loudly later if this doesn't succeed
-        (e.g. no network access to fetch the extension on first run)."""
+        """Load DuckDB's `delta` extension so EXTERNAL Delta tables (written by e.g. a real
+        Spark/notebook session sharing the data volume) can be read via
+        `delta_scan(storage_location)`.
+
+        Two paths, because only one of them may touch the network:
+
+        - `extension_dir` set (the Docker image, populated at build time): `LOAD` only. An
+          `INSTALL` here would be exactly the runtime download this directory exists to avoid.
+        - `extension_dir` unset (`pip install minilake`): `INSTALL` then `LOAD`, which needs
+          network access once, on first run.
+
+        Either way a failure is logged rather than raised — the server is still fully usable
+        for everything that is not an EXTERNAL Delta table, and `delta_scan()` fails on its
+        own terms later.
+        """
         conn = self._uc_connection
         if conn is None:
+            return
+        if self.extension_dir is not None:
+            try:
+                conn.execute("LOAD delta")
+                logger.info(f"DuckDB delta extension loaded from {self.extension_dir}")
+            except Exception as e:
+                logger.error(
+                    f"Failed to load the pre-installed DuckDB delta extension from "
+                    f"{self.extension_dir} (duckdb {duckdb.__version__}): {e}. "
+                    "EXTERNAL Delta tables will not be readable. Rebuild the image, or unset "
+                    "MINILAKE_DUCKDB_EXTENSION_DIR to fall back to downloading the extension."
+                )
             return
         try:
             conn.execute("INSTALL delta")
@@ -104,7 +147,7 @@ class DuckDBPool:
                 # Create a new connection (in-memory by default, or persisted file if preferred)
                 wh_path = self.data_dir / "warehouses" / f"{warehouse_id}.duckdb"
                 wh_path.parent.mkdir(parents=True, exist_ok=True)
-                conn = duckdb.connect(str(wh_path))
+                conn = duckdb.connect(str(wh_path), config=self._connect_config())
                 self._warehouse_connections[warehouse_id] = conn
                 self._warehouse_locks[warehouse_id] = asyncio.Lock()
                 logger.info(f"Created DuckDB connection for warehouse {warehouse_id}")

--- a/tests/test_docker_executor.py
+++ b/tests/test_docker_executor.py
@@ -71,6 +71,7 @@ def test_prepare_ivy_cache_creates_resolution_dir(monkeypatch, tmp_path: Path):
     without this the first --packages run dies with FileNotFoundException.
     """
     monkeypatch.setattr(docker_executor.settings, "data_dir", tmp_path)
+    monkeypatch.delenv("MINILAKE_IVY_SEED", raising=False)
 
     ivy_home = Path(docker_executor._prepare_ivy_cache())
 
@@ -78,6 +79,70 @@ def test_prepare_ivy_cache_creates_resolution_dir(monkeypatch, tmp_path: Path):
     assert (ivy_home / "cache").is_dir()
     assert (ivy_home / "jars").is_dir()
     print("✓ Ivy home is pre-created with its cache/ and jars/ subdirs")
+
+
+@pytest.mark.crud
+def test_prepare_ivy_cache_seeds_jars_from_the_image(monkeypatch, tmp_path: Path):
+    """The image's pre-resolved jars land on the shared volume, so a job needs no Maven.
+
+    The Spark container is a sibling and cannot see MINILAKE_IVY_SEED inside the minilake
+    container — only the data volume — so the seed has to be a real copy.
+    """
+    seed = tmp_path / "image-ivy"
+    (seed / "jars").mkdir(parents=True)
+    (seed / "jars" / "delta-spark_2.12-3.2.1.jar").write_text("jar")
+    (seed / "cache").mkdir()
+    (seed / "cache" / "ivy-3.2.1.xml").write_text("<ivy/>")
+
+    data_dir = tmp_path / "data"
+    monkeypatch.setattr(docker_executor.settings, "data_dir", data_dir)
+    monkeypatch.setenv("MINILAKE_IVY_SEED", str(seed))
+
+    ivy_home = Path(docker_executor._prepare_ivy_cache())
+
+    assert (ivy_home / "jars" / "delta-spark_2.12-3.2.1.jar").read_text() == "jar"
+    # The ivy-*.xml metadata matters as much as the jar: without it Ivy re-resolves from
+    # the network even when the jar is already on disk.
+    assert (ivy_home / "cache" / "ivy-3.2.1.xml").is_file()
+    assert (ivy_home / docker_executor._IVY_SEED_MARKER).exists()
+    print("✓ Ivy cache seeded from the image onto the shared volume")
+
+
+@pytest.mark.crud
+def test_ivy_cache_seed_is_idempotent_and_never_clobbers(monkeypatch, tmp_path: Path):
+    """A second call is a no-op, and a jar the user already resolved survives."""
+    seed = tmp_path / "image-ivy"
+    (seed / "jars").mkdir(parents=True)
+    (seed / "jars" / "delta-spark_2.12-3.2.1.jar").write_text("from-image")
+
+    data_dir = tmp_path / "data"
+    monkeypatch.setattr(docker_executor.settings, "data_dir", data_dir)
+    monkeypatch.setenv("MINILAKE_IVY_SEED", str(seed))
+
+    ivy_home = Path(docker_executor._prepare_ivy_cache())
+    user_jar = ivy_home / "jars" / "user-resolved.jar"
+    user_jar.write_text("resolved-later")
+    (ivy_home / "jars" / "delta-spark_2.12-3.2.1.jar").write_text("locally-updated")
+
+    docker_executor._prepare_ivy_cache()
+
+    assert user_jar.read_text() == "resolved-later"
+    assert (ivy_home / "jars" / "delta-spark_2.12-3.2.1.jar").read_text() == "locally-updated"
+    print("✓ Ivy seed runs once and leaves an existing cache alone")
+
+
+@pytest.mark.crud
+def test_ivy_cache_seed_survives_a_missing_seed_dir(monkeypatch, tmp_path: Path):
+    """A bad MINILAKE_IVY_SEED degrades to Maven resolution, it does not break job setup."""
+    data_dir = tmp_path / "data"
+    monkeypatch.setattr(docker_executor.settings, "data_dir", data_dir)
+    monkeypatch.setenv("MINILAKE_IVY_SEED", str(tmp_path / "does-not-exist"))
+
+    ivy_home = Path(docker_executor._prepare_ivy_cache())
+
+    assert (ivy_home / "cache").is_dir()
+    assert not (ivy_home / docker_executor._IVY_SEED_MARKER).exists()
+    print("✓ a missing Ivy seed directory is harmless")
 
 
 @pytest.mark.error

--- a/tests/test_duckdb_extensions.py
+++ b/tests/test_duckdb_extensions.py
@@ -1,0 +1,58 @@
+"""DuckDB extension availability tests.
+
+The `delta` extension is what makes EXTERNAL Delta tables readable (`delta_scan`). It used
+to be downloaded from extensions.duckdb.org on first boot, which made a fresh container
+useless without internet access. The Docker image now bakes it in at build time, and these
+tests assert that through the SQL API — the same path a user's query takes.
+"""
+
+import os
+
+import pytest
+from databricks.sdk import WorkspaceClient
+
+# Matches MINILAKE_DUCKDB_EXTENSION_DIR in Dockerfile / Dockerfile.test.
+BAKED_EXTENSION_DIR = "/opt/duckdb-extensions"
+
+# Same detection conftest.py uses to tell the Docker Compose stack from a local subprocess run.
+DOCKER_ENV = os.getenv("MINILAKE_DATA_DIR") == "/data"
+
+
+def _delta_extension_row(workspace_client: WorkspaceClient) -> list[str]:
+    wh = workspace_client.warehouses.create(name="ext_wh")
+    result = workspace_client.statement_execution.execute_statement(
+        warehouse_id=wh.id,
+        statement=("SELECT loaded, installed, install_path FROM duckdb_extensions() WHERE extension_name = 'delta'"),
+    )
+    rows = result.result.data_array
+    assert rows, "duckdb_extensions() knows nothing about a 'delta' extension"
+    return rows[0]
+
+
+@pytest.mark.crud
+def test_delta_extension_is_loaded_at_startup(workspace_client: WorkspaceClient):
+    """The delta extension is installed and loaded on the shared UC connection."""
+    loaded, installed, _install_path = _delta_extension_row(workspace_client)
+
+    assert str(loaded).lower() == "true", "delta extension is not loaded"
+    assert str(installed).lower() == "true", "delta extension is not installed"
+
+    print("✓ delta extension installed and loaded")
+
+
+@pytest.mark.crud
+@pytest.mark.skipif(not DOCKER_ENV, reason="the pre-baked extension directory only exists in the image")
+def test_delta_extension_comes_from_the_image_not_a_download(workspace_client: WorkspaceClient):
+    """The loaded extension resolves inside the image's build-time directory.
+
+    This is the actual offline guarantee: an extension served from anywhere else (notably
+    $HOME/.duckdb) means it was fetched over the network at runtime.
+    """
+    _loaded, _installed, install_path = _delta_extension_row(workspace_client)
+
+    assert install_path.startswith(BAKED_EXTENSION_DIR), (
+        f"delta extension loaded from {install_path}, expected it under {BAKED_EXTENSION_DIR} — "
+        "it was downloaded at runtime instead of coming from the image"
+    )
+
+    print(f"✓ delta extension served from the image: {install_path}")

--- a/uv.lock
+++ b/uv.lock
@@ -714,7 +714,7 @@ wheels = [
 
 [[package]]
 name = "minilake"
-version = "1.5.1"
+version = "1.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Problem

`docker run ghcr.io/dmux/minilake:latest` downloaded two things on first use, so on a machine without internet the server booted and then failed on the first real query.

1. **DuckDB `delta` extension** — `duckdb_pool.py` ran `INSTALL delta` at startup, fetching from `extensions.duckdb.org` into `$HOME/.duckdb`. Not a volume, so every fresh container re-downloaded it. The failure was swallowed as a `warning` and the health check stayed green, so it surfaced three layers away as a broken `delta_scan()`. `FEATURES.md` claimed this "fails loudly" — it did not.
2. **Spark Delta / Unity Catalog jars** — `spark-submit --packages` resolved from Maven Central on the first job run. The Ivy cache on the data volume avoided repeat resolution but not the first fetch, and the volume starts empty.

## Changes

**DuckDB extension.** Both Dockerfiles `INSTALL` it at build time into `MINILAKE_DUCKDB_EXTENSION_DIR` (`/opt/duckdb-extensions`), and the build fails outright if the fetch does not land — better than silently publishing an image that goes back to downloading at boot. At runtime the pool only `LOAD`s it, with `autoinstall_known_extensions=False` so nothing can be fetched behind your back. A plain `pip install minilake` keeps the old `INSTALL` path; there is no image to bake anything into.

**Spark jars.** A new `sparkjars` build stage resolves Delta + the UC connector with `spark-submit` itself rather than curl — Ivy needs the `ivy-*.xml` metadata next to the jar, and without it re-resolves over the network even when the jar is on disk. The job container is a sibling and cannot see inside minilake's container, so `_seed_ivy_cache()` copies the baked cache onto the shared data volume once per volume, chmod'd for the Spark image's uid 185.

Both directories live outside `WORKDIR`: `docker-compose.test.yml` bind-mounts the repo over `/opt/minilake` and would otherwise hide them at runtime.

**Still a network call:** the Spark image `docker pull`. An image cannot contain another image. `MINILAKE_SPARK_PREWARM=0` skips the attempt, and the docs say to pull it once up front.

## Verification

- Full Docker suite: **234 passed**.
- New `tests/test_duckdb_extensions.py` runs against the Docker stack (not skipped) and asserts the extension resolves to `/opt/duckdb-extensions/v1.5.5/linux_amd64/delta.duckdb_extension` — anywhere else means it was downloaded at runtime.
- Four new `_seed_ivy_cache` tests: seeding, idempotency, non-clobbering, missing seed dir.
- `scripts/verify-offline.sh` passes under `docker run --network none`.
- Jars proven offline directly: `spark-submit --packages` on an `--internal` Docker network (no route out) reported `0 artifacts copied, 30 already retrieved` and the script ran.

## Version

`1.5.1` → `1.6.0`. Minor rather than patch: the image gains a capability it did not have, plus `MINILAKE_IVY_SEED` and `MINILAKE_SPARK_PREWARM`. No existing behaviour changes.

## Review notes

- The `sparkjars` stage is pinned to `--platform=$BUILDPLATFORM` (jars are architecture-independent, so it skips QEMU in the multi-arch release build). The DuckDB `RUN` is deliberately *not* — that extension is per-architecture and must run on the target platform.
- Image size grows by roughly 100 MB.
- Drive-by: `docs/configuration.md` documented `MINILAKE_DUCKDB_MEMORY_LIMIT` as "Passed to DuckDB", but it is never applied to any connection. Marked as a no-op; fixing it is out of scope here.
